### PR TITLE
Open simplex 2 s fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,6 +116,27 @@ dependencies {
 }
 
 
+// Disable signing unless -Psign is explicitly passed — allows publishToMavenLocal / Repsy without GPG setup.
+tasks.withType(org.gradle.plugins.signing.Sign::class.java).configureEach {
+    onlyIf { project.hasProperty("sign") }
+}
+
+publishing {
+    repositories {
+        maven {
+            name = "Repsy"
+            url = uri("https://repo.repsy.io/mvn/diytechy/seismic")
+            credentials {
+                username = project.findProperty("repsy.user") as String? ?: System.getenv("REPSY_USERNAME")
+                password = project.findProperty("repsy.key") as String? ?: System.getenv("REPSY_PASSWORD")
+            }
+        }
+    }
+}
+
+// Override axion-release version for local patched builds. Remove this line for real releases.
+version = "2.5.7-PATCHED"
+
 tasks {
     withType<JavaCompile>().configureEach {
         options.isFork = true
@@ -135,6 +156,10 @@ tasks {
         from(layout.buildDirectory.dir("tmp/META-INF")) {
             into("META-INF")
         }
+    }
+
+    named("build") {
+        finalizedBy("publishToMavenLocal")
     }
 
     register("dumpClasses") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,27 +116,6 @@ dependencies {
 }
 
 
-// Disable signing unless -Psign is explicitly passed — allows publishToMavenLocal / Repsy without GPG setup.
-tasks.withType(org.gradle.plugins.signing.Sign::class.java).configureEach {
-    onlyIf { project.hasProperty("sign") }
-}
-
-publishing {
-    repositories {
-        maven {
-            name = "Repsy"
-            url = uri("https://repo.repsy.io/mvn/diytechy/seismic")
-            credentials {
-                username = project.findProperty("repsy.user") as String? ?: System.getenv("REPSY_USERNAME")
-                password = project.findProperty("repsy.key") as String? ?: System.getenv("REPSY_PASSWORD")
-            }
-        }
-    }
-}
-
-// Override axion-release version for local patched builds. Remove this line for real releases.
-version = "2.5.7-PATCHED"
-
 tasks {
     withType<JavaCompile>().configureEach {
         options.isFork = true
@@ -156,10 +135,6 @@ tasks {
         from(layout.buildDirectory.dir("tmp/META-INF")) {
             into("META-INF")
         }
-    }
-
-    named("build") {
-        finalizedBy("publishToMavenLocal")
     }
 
     register("dumpClasses") {

--- a/src/main/java/com/dfsek/seismic/algorithms/sampler/noise/simplex/OpenSimplex2SSampler.java
+++ b/src/main/java/com/dfsek/seismic/algorithms/sampler/noise/simplex/OpenSimplex2SSampler.java
@@ -50,7 +50,7 @@ public class OpenSimplex2SSampler extends OpenSimplex2StyleSampler {
         double a0 = (2.0 / 3.0) - x0 * x0 - y0 * y0;
         double value = (a0 * a0) * (a0 * a0) * SimplexStyleSampler.gradCoord(grads, seed, i, j, x0, y0);
 
-        double a1 = OpenSimplex2StyleSampler.GRADIENT_SCALE_PRIMARY * t + OpenSimplex2StyleSampler.GRADIENT_SCALE_SECONDARY;
+        double a1 = OpenSimplex2StyleSampler.GRADIENT_SCALE_PRIMARY * t + OpenSimplex2StyleSampler.GRADIENT_SCALE_SECONDARY + a0;
         double x1 = x0 - OpenSimplex2StyleSampler.ONE_MINUS_DOUBLE_UNSKEW_2D;
         double y1 = y0 - OpenSimplex2StyleSampler.ONE_MINUS_DOUBLE_UNSKEW_2D;
         value += (a1 * a1) * (a1 * a1) * SimplexStyleSampler.gradCoord(grads, seed, i1, j1, x1, y1);
@@ -68,7 +68,7 @@ public class OpenSimplex2SSampler extends OpenSimplex2StyleSampler {
                 }
             } else {
                 double x2 = x0 + OpenSimplex2StyleSampler.UNSKEW_2D;
-                double y2 = y0 + OpenSimplex2StyleSampler.UNSKEW_2D;
+                double y2 = y0 + OpenSimplex2StyleSampler.UNSKEW_2D_MINUS_1;
                 double a2 = (2.0 / 3.0) - x2 * x2 - y2 * y2;
                 if(a2 > 0) {
                     value += (a2 * a2) * (a2 * a2) * SimplexStyleSampler.gradCoord(grads, seed, i, j + NoiseFunction.PRIME_Y, x2, y2);


### PR DESCRIPTION
1. a1 formula was missing `+ a0`: the second primary vertex attenuation
   must include a0 so the formula equals the correct distance expression
   (2/3 - x1^2 - y1^2). Without it a1 was ~0 everywhere, exposing the
   raw simplex lattice as visible seams across the entire output.

2. y2 coordinate for the (i, j+PRIME_Y) branch used UNSKEW_2D instead
   of UNSKEW_2D_MINUS_1. The correct unskewed displacement from that
   vertex to the query point is (U, U-1), not (U, U).

Both bugs identified by comparing getNoiseRaw with the already-correct
getNoiseDerivativeRaw and verified algebraically.